### PR TITLE
Ghost Listによるお化け情報のストアを作成

### DIFF
--- a/src/GhostList.js
+++ b/src/GhostList.js
@@ -1,0 +1,14 @@
+export default {
+  ghost_list:[
+    {
+      no: 1,
+      image_id: "#ghost_woman",
+      size: { width: 2, height: 3 },
+      position: { x: 0, y: 2, z: -10 },
+      event_area: {
+        x_area: [-2.5, 2.5],
+        z_area: [-7, -10]
+      }
+    }
+  ]
+}

--- a/src/components/AframeApp.vue
+++ b/src/components/AframeApp.vue
@@ -15,7 +15,7 @@
       :size="ghost.size"
       :position="ghost.position"
       :event_area="ghost.event_area"
-      isDisplay="true"
+      isDisplay=true
     />
     <!-- Map Ground Component -->
     <StraightRoad

--- a/src/components/AframeApp.vue
+++ b/src/components/AframeApp.vue
@@ -8,7 +8,15 @@
     </a-assets>
 
     <!-- Ghost Component -->
-    <Ghost img_path="#ghost_woman" :cordinate="cordinate" :size="size" isDisplay="true" />
+    <Ghost
+      v-for="ghost in ghost_list"
+      :key="ghost.no"
+      :img_path="ghost.image_id"
+      :size="ghost.size"
+      :position="ghost.position"
+      :event_area="ghost.event_area"
+      isDisplay="true"
+    />
     <!-- Map Ground Component -->
     <StraightRoad
       v-for="i in map_length"
@@ -24,22 +32,14 @@
 <script>
 import Ghost from "@/components/Ghost.vue"
 import StraightRoad from "@/components/StraightRoad.vue"
+import GhostList from "@/GhostList.js"
 
 export default {
   name: "AframeApp",
   data(){
     return {
-      // demo property data for ghost component
-      cordinate: {
-        x: 0,
-        y: 2,
-        z: -10
-      },
-      size: {
-        width: 2,
-        height: 3
-      },
       map_length: 20,
+      ghost_list: GhostList.ghost_list
     }
   },
   components: {

--- a/src/components/Ghost.vue
+++ b/src/components/Ghost.vue
@@ -4,7 +4,7 @@
     :geometry="geometry"
     :position="position"
     :material="material"
-  />
+  ></a-entity>
 </template>
 
 <script>

--- a/src/components/Ghost.vue
+++ b/src/components/Ghost.vue
@@ -2,7 +2,7 @@
   <a-entity
     v-if="isDisplay"
     :geometry="geometry"
-    :position="cordinate"
+    :position="position"
     :material="material"
   />
 </template>
@@ -10,13 +10,10 @@
 <script>
 export default {
   name: 'Ghost',
-  // props: ['img_path', 'cordinate', 'size', 'isDisplay'],
   props: {
-    img_path: {
-      type: String,
-      required: true
-    },
-    cordinate: {
+    img_path: { type: String, required: true },
+    isDisplay: { type: Boolean, default: true },
+    position: {
       type: Object,
       default: function() {
         return { x: 0, y: 0, z: 0 }
@@ -28,10 +25,12 @@ export default {
         return { width: 1, height: 1 }
       }
     },
-    isDisplay: {
-      type: Boolean,
-      default: true
-    }
+    event_area: {
+      type: Object,
+      default: function() {
+        return { x_area: [0], z_area: [0] }
+      }
+    },
   },
   data(){
     return {
@@ -43,7 +42,9 @@ export default {
       },
       // material information
       material: {
-        src: this.img_path
+        src: this.img_path,
+        shader: "standard",
+        transparent: true
       }
     }
   },


### PR DESCRIPTION
複数のおばけ情報を定義できるようにGhostList.jsを作成
以下の4つを定義可能
- No
- a-assetsのID
- 画像サイズ
- 表示位置
- イベント発生エリア

ex)
```
{
  no: 1,
  image_id: "#ghost_woman",
  size: { width: 2, height: 3 },
  position: { x: 0, y: 2, z: -10 },
  event_area: {
    x_area: [-2.5, 2.5],
    z_area: [-7, -10]
  }
}
```