### PR TITLE
VRゴーグルブラウザでVRモードに入れない不具合を修正

### DIFF
--- a/src/vue-components/AframeApp.vue
+++ b/src/vue-components/AframeApp.vue
@@ -1,5 +1,5 @@
 <template lang="html">
-  <a-scene>
+  <a-scene vr-mode-ui="enabled: true">
     <!-- Asset Files -->
     <Assets />
 

--- a/src/vue-components/App.vue
+++ b/src/vue-components/App.vue
@@ -1,7 +1,5 @@
 <template>
-  <div id="app">
-    <AframeApp />
-  </div>
+  <AframeApp></AframeApp>
 </template>
 
 <script>


### PR DESCRIPTION
# New Pull Request

## PR type

- [x] bugfix
- [ ] feature

## 修正内容
以下のように`div`タグが入れ子になっている状態で`<a-scene>`があるとVRゴーグル上のブラウザでVR UIが使えなかったので修正

```
<div>
  <div>
    <a-scene></a-scene>
  </div>
</div>
```

## 補足事項
特になし